### PR TITLE
Add Home LiveView

### DIFF
--- a/lib/elixir_most_wanted/wanteds.ex
+++ b/lib/elixir_most_wanted/wanteds.ex
@@ -1,0 +1,18 @@
+defmodule ElixirMostWanted.Wanteds do
+  import Ecto.Query
+  alias ElixirMostWanted.Repo
+
+  alias ElixirMostWanted.Wanteds.{Wanted, Vote}
+
+  def list_most_wanted do
+    from(w in Wanted,
+      join: v in Vote,
+      on: v.wanted_id == w.id,
+      where: is_nil(w.completed_at),
+      group_by: [w.id],
+      select: %Vote{wanted: w, count: count(v.wanted_id)},
+      order_by: [desc: :count]
+    )
+    |> Repo.all()
+  end
+end

--- a/lib/elixir_most_wanted/wanteds/vote.ex
+++ b/lib/elixir_most_wanted/wanteds/vote.ex
@@ -1,0 +1,12 @@
+defmodule ElixirMostWanted.Wanteds.Vote do
+  use Ecto.Schema
+
+  @primary_key false
+
+  schema "votes" do
+    belongs_to :user, ElixirMostWanted.Accounts.User
+    belongs_to :wanted, ElixirMostWanted.Wanteds.Wanted
+    field :count, :integer, virtual: true
+    timestamps(updated_at: false, type: :utc_datetime)
+  end
+end

--- a/lib/elixir_most_wanted/wanteds/wanted.ex
+++ b/lib/elixir_most_wanted/wanteds/wanted.ex
@@ -1,0 +1,13 @@
+defmodule ElixirMostWanted.Wanteds.Wanted do
+  use Ecto.Schema
+
+  schema "wanteds" do
+    field :name, :string
+    field :purpose, :string
+    field :body, :string
+    field :slug_id, :string
+    field :completed_at, :utc_datetime
+    has_many :votes, ElixirMostWanted.Wanteds.Vote
+    timestamps(type: :utc_datetime)
+  end
+end

--- a/lib/elixir_most_wanted_web/controllers/page_controller.ex
+++ b/lib/elixir_most_wanted_web/controllers/page_controller.ex
@@ -1,9 +1,0 @@
-defmodule ElixirMostWantedWeb.PageController do
-  use ElixirMostWantedWeb, :controller
-
-  def home(conn, _params) do
-    # The home page is often custom made,
-    # so skip the default app layout.
-    render(conn, :home, layout: false)
-  end
-end

--- a/lib/elixir_most_wanted_web/live/home_live/index.ex
+++ b/lib/elixir_most_wanted_web/live/home_live/index.ex
@@ -1,0 +1,15 @@
+defmodule ElixirMostWantedWeb.HomeLive.Index do
+  use ElixirMostWantedWeb, :live_view
+
+  alias ElixirMostWanted.Wanteds
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {
+      :ok,
+      socket
+      |> stream_configure(:wanteds, dom_id: &"wanteds-#{&1.wanted.id}")
+      |> stream(:wanteds, Wanteds.list_most_wanted())
+    }
+  end
+end

--- a/lib/elixir_most_wanted_web/live/home_live/index.html.heex
+++ b/lib/elixir_most_wanted_web/live/home_live/index.html.heex
@@ -1,0 +1,18 @@
+<.header>
+  Listing Most Wanteds
+</.header>
+
+<ol phx-update="stream" id="wanteds" class="my-6">
+  <li :for={{id, vote} <- @streams.wanteds} id={id} class="flex justify-between">
+    <div class="py-3 ">
+      <h2 class="w-full font-medium"><%= vote.wanted.name %></h2>
+      <p class="text-zinc-700"><%= vote.wanted.purpose || "Some purpose text here" %></p>
+    </div>
+    <div class="flex flex-col text-center">
+      <span class="text-2xl font-extrabold">
+        <%= vote.count %>
+      </span>
+      votes
+    </div>
+  </li>
+</ol>

--- a/lib/elixir_most_wanted_web/router.ex
+++ b/lib/elixir_most_wanted_web/router.ex
@@ -20,7 +20,7 @@ defmodule ElixirMostWantedWeb.Router do
   scope "/", ElixirMostWantedWeb do
     pipe_through :browser
 
-    get "/", PageController, :home
+    live "/", HomeLive.Index, :index
   end
 
   scope "/", ElixirMostWantedWeb do

--- a/priv/repo/migrations/20240602233502_create_votes.exs
+++ b/priv/repo/migrations/20240602233502_create_votes.exs
@@ -1,0 +1,13 @@
+defmodule ElixirMostWanted.Repo.Migrations.CreateVotes do
+  use Ecto.Migration
+
+  def change do
+    create table("votes", primary_key: false) do
+      add :user_id, references(:users, on_delete: :delete_all)
+      add :wanted_id, references(:wanteds, on_delete: :delete_all)
+      timestamps(updated_at: false, type: :utc_datetime)
+    end
+
+    create unique_index("votes", [:wanted_id, :user_id])
+  end
+end

--- a/test/elixir_most_wanted_web/controllers/page_controller_test.exs
+++ b/test/elixir_most_wanted_web/controllers/page_controller_test.exs
@@ -1,8 +1,0 @@
-defmodule ElixirMostWantedWeb.PageControllerTest do
-  use ElixirMostWantedWeb.ConnCase
-
-  test "GET /", %{conn: conn} do
-    conn = get(conn, ~p"/")
-    assert html_response(conn, 200) =~ "Peace of mind from prototype to production"
-  end
-end

--- a/test/elixir_most_wanted_web/live/home_live_test.exs
+++ b/test/elixir_most_wanted_web/live/home_live_test.exs
@@ -1,0 +1,13 @@
+defmodule ElixirMostWantedWeb.HomeLiveTest do
+  use ElixirMostWantedWeb.ConnCase
+
+  import Phoenix.LiveViewTest
+
+  describe "Index" do
+    test "lists all wanteds", %{conn: conn} do
+      {:ok, _index_live, html} = live(conn, ~p"/")
+
+      assert html =~ "Listing Most Wanteds"
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a Home Liveview at the root `/` path.

The Home LiveView lists the most wanted by number of votes.

Votes are stored in the `vote` table, which  references the `wanteds` and `users`. 

Each row in the votes table counts as one vote for a wanted, and a unique index ensures each user can only vote once.
(Issue #4 did not mention creating a votes table but I didn't think it was possible to complete without storing votes somehow). 

A wanted that is completed is not shown in the Home view.

![CleanShot 2024-06-03 at 10 48 00@2x](https://github.com/ElixirMostWanted/elixirmostwanted.com/assets/22266/3cf55619-8aea-4937-9f93-5ebc70749592)

This PR does not cover creating wanteds (see #7 ) or adding votes.

Closes #4 